### PR TITLE
Don't use Javadoc in field documentation

### DIFF
--- a/src/main/java/io/github/hzpz/spring/boot/autoconfigure/mongeez/MongeezProperties.java
+++ b/src/main/java/io/github/hzpz/spring/boot/autoconfigure/mongeez/MongeezProperties.java
@@ -26,10 +26,6 @@ public class MongeezProperties {
 
     /**
      * Location of migration script.
-     *
-     * @see <a
-     * href="https://github.com/secondmarket/mongeez/wiki/How-to-use-mongeez#create-a-mongeezxml-file-that-include-all-change-logs">
-     * Create a mongeez.xml file that includes all change logs</a>
      */
     private String location = "db/mongeez.xml";
 
@@ -50,7 +46,6 @@ public class MongeezProperties {
 
     /**
      * The database to migrate.
-
      */
     private String database;
 


### PR DESCRIPTION
The meta-data generator requires the documentation for keys to be simple
as it does not process javadoc tags. `mongeez. location` is not compliant
to that.

`mongeez.database` had a small javadoc tag glitch as well.
