### PR TITLE
Fix Mongeez authentication

### DIFF
--- a/src/main/java/io/github/hzpz/spring/boot/autoconfigure/mongeez/MongeezAutoConfiguration.java
+++ b/src/main/java/io/github/hzpz/spring/boot/autoconfigure/mongeez/MongeezAutoConfiguration.java
@@ -18,6 +18,7 @@ import com.mongodb.Mongo;
 import org.mongeez.Mongeez;
 import org.mongeez.MongeezRunner;
 import org.mongeez.MongoAuth;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -30,7 +31,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoProperties;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -89,8 +89,9 @@ public class MongeezAutoConfiguration {
                 MongoAuth auth = new MongoAuth(mongeezProperties.getUsername(), mongeezProperties.getPassword());
                 mongeez.setAuth(auth);
             } else if (hasCredentials(mongoProperties)) {
-                MongoAuth auth = new MongoAuth(mongoProperties.getUsername(), new String(mongoProperties.getPassword()));
-                mongeez.setAuth(auth);
+                String msg = "Credentials under spring.data.mongodb.* found but no credentials for mongeez.* defined." +
+                        "Please add correct mongeez.password and mongeez.username";
+                throw new BeanCreationException(msg);
             }
             mongeez.setFile(resourceLoader.getResource(mongeezProperties.getLocation()));
             return mongeez;

--- a/src/test/java/io/github/hzpz/spring/boot/autoconfigure/mongeez/MongeezAutoConfigurationTests.java
+++ b/src/test/java/io/github/hzpz/spring/boot/autoconfigure/mongeez/MongeezAutoConfigurationTests.java
@@ -89,6 +89,16 @@ public class MongeezAutoConfigurationTests {
     }
 
     @Test(expected = BeanCreationException.class)
+    public void shouldFailIfOnlyMongoCredentialsProvided() {
+        String mongoUsername = "foo";
+        String mongoPassword = "bar";
+        EnvironmentTestUtils.addEnvironment(this.context, "spring.data.mongodb.username:" + mongoUsername);
+        EnvironmentTestUtils.addEnvironment(this.context, "spring.data.mongodb.password:" + mongoPassword);
+        registerAndRefresh(DoNotExecuteMongeezPostProcessor.class,
+                MongoAutoConfiguration.class, MongeezAutoConfiguration.class);
+    }
+
+    @Test(expected = BeanCreationException.class)
     public void shouldFailIfLocationDoesNotExist() {
         EnvironmentTestUtils.addEnvironment(this.context, "mongeez.location:does/not/exist");
         registerAndRefresh(DoNotExecuteMongeezPostProcessor.class,


### PR DESCRIPTION
When you set user credentials with spring.data.mongodb.\* properties but not for mongeez as well, authentication will always fail during migration. 
The reason is that when spring creates the MongoClient bean, it clears the password from the MongoProperties bean (method clearPassword() in MongoProperties is called).
The Mongeez bean method first looks if credentials are provided in the mongeez property namespace, then checks if those are provided in the spring.data property namespace and tries to use those.
This cannot ever work as the password will never be set.

This PR fixes this issue, by throwing a BeanCreationException if only spring's properties are defined.
An alternative (but more hacky) way to fix this would be to run before MongoAutoConfiguration, instantiate the MongoProperties bean via an @EnableConfigurationProperties annotation, and then copy those properties over to the MongeezProperties bean, if they are not set already.
